### PR TITLE
CI: Fix dependabot gomod directory and enhance configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,23 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /
+    directory: /scripts
     schedule:
       interval: daily
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(deps):"
+    reviewers:
+      - "dongjiang1989"
+      - "FenjuFu"
+      - "scguoi"
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first contribution, read our Getting Started guide https://github.com/iflytek/community/blob/main/CONTRIBUTING.md

-->

## Summary                                                                                                                                                                                            

- Fix gomod package-ecosystem directory from `/` to `/scripts` to match the actual location of `go.mod`                                                                                             
- Add `open-pull-requests-limit: 2` to control the number of concurrent dependabot PRs                                                                                                                
- Add commit message prefix `chore(deps):` for consistent commit formatting                                                                                                                           
- Add reviewers: `dongjiang1989`, `FenjuFu`, `scguoi` for automatic PR review assignment                                                                                                              
- Add `go-minor-patch` group to consolidate minor and patch Go dependency updates into a single PR                                                                                                    
                                                                                                                                                                                                          
## Changes                                                                                                                                                                                            
                                                                                                                                                                                                          
| File | Description |                                                                                                                                                                                
|------|-------------|                                                                                                                                                                              
| `.github/dependabot.yml` | Fix gomod directory path; add PR limit, commit-message prefix, reviewers, and update groups |

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
<!--
Please leave this section blank if you don't have any special notes.
-->

The `gomod` directory was incorrectly pointing to `/` instead of `/scripts`, causing dependabot to miss Go dependency updates. 